### PR TITLE
make service start after mosquitto and wb-configs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-metrics (0.2.1) stable; urgency=medium
+
+  * Make service start after mosquitto and wb-configs
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 20 Oct 2022 15:33:37 +0600
+
 wb-mqtt-metrics (0.2.0) stable; urgency=low
 
   * Support connection to Mosquitto through unix socket

--- a/debian/wb-mqtt-metrics.service
+++ b/debian/wb-mqtt-metrics.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=metrics sender.
-Wants=wb-hwconf-manager.service wb-modules.service
-After=wb-hwconf-manager.service wb-modules.service
+After=wb-configs.service mosquitto.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
С переходом на bullseye сервис перестал запускаться, хотя если перезапустить сервис в загруженной ОС, всё работает как надо. Похоже, обострились проблемы с непрописанным порядком запуска.

Убрал всё лишнее и добавил реально нужные сервисы: mosquitto - потому что без брокера никак, wb-configs - чтобы в доступе точно были все конфиги.

Убрал `Wants`, чтобы не путался под ногами (хотя на самом деле надо подумать о том, чтобы выставить корректные зависимости, потому что на деле сервисы плохо переживают перезапуск mosquitto, например).