### PR TITLE
do not use additional thread to publish values

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-metrics (0.2.3) stable; urgency=medium
+
+  * do not use additional thread to publish values
+    (this may leave duplicate threads after MQTT reconnections)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 08 Feb 2023 20:35:57 +0600
+
 wb-mqtt-metrics (0.2.2) stable; urgency=medium
 
   * fix codestyle

--- a/wb/mqtt_metrics/metrics_sender.py
+++ b/wb/mqtt_metrics/metrics_sender.py
@@ -3,7 +3,6 @@ import random
 import sys
 import time
 import urllib.parse
-from threading import Thread
 
 import paho_socket
 import yaml
@@ -13,36 +12,17 @@ from yaml.loader import SafeLoader
 from .device_messenger import DeviceMessenger
 from .metrics_dict import METRICS
 
-metrics = []
 
-
-def connect_mqtt(broker, port, device_name, metrics_list, period) -> mqtt_client:
-    thread_info = {"thread": None, "must_work": False}
-
+def connect_mqtt(broker, port) -> mqtt_client:
     def on_connect(client, userdata, flags, rc):
         if rc == 0:
             print("Connected to MQTT Broker!")
-            messenger = DeviceMessenger(client=client, device_name=device_name)
-            create_device(metrics_list, messenger)
-
-            thread_info["must_work"] = True
-            thread_info["thread"] = Thread(
-                target=thread2_loop,
-                args=(
-                    period,
-                    messenger,
-                    thread_info,
-                ),
-            )
-            thread_info["thread"].start()
         else:
             print("Failed to connect, return code %d\n", rc)
 
     def on_disconnect(client, userdata, rc):
         if rc != 0:
             print("Unexpected disconnection.")
-        thread_info["must_work"] = False
-        thread_info["thread"].join()
 
     client_id = "python-mqtt-wb-{0}".format(random.randint(0, 255))
     url = urllib.parse.urlparse(broker)
@@ -58,18 +38,6 @@ def connect_mqtt(broker, port, device_name, metrics_list, period) -> mqtt_client
         client.connect(broker, port)
 
     return client
-
-
-def create_device(metrics_list, messenger):
-    for metric in metrics_list:
-        metrics.append(METRICS[metric](messenger))
-
-
-def thread2_loop(period, messenger: DeviceMessenger, thread_info):
-    while thread_info["must_work"]:
-        for metric in metrics:
-            metric.send(messenger)
-        time.sleep(period)
 
 
 def main(argv=None):
@@ -94,8 +62,22 @@ def main(argv=None):
 
         metrics_list = data["metrics"]["list"]
 
-    client = connect_mqtt(broker, port, device_name, metrics_list, period)
-    client.loop_forever()
+    client = connect_mqtt(broker, port)
+    messenger = DeviceMessenger(client=client, device_name=device_name)
+
+    metrics = []
+    for metric in metrics_list:
+        metrics.append(METRICS[metric](messenger))
+
+    try:
+        client.loop_start()
+
+        while True:
+            for metric in metrics:
+                metric.send(messenger)
+            time.sleep(period)
+    finally:
+        client.loop_stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Снова жаловались на большое потребление CPU через какое-то время работы.

Посмотрел внимательно через strace и понял, что сервис как не в себя публикует сообщения большими пачками. Почитал код и нашёл там эту часть про треды. Ничего не мешает сделать несколько тредов при сбоях подключения к mosquitto и заставить их работать одновременно.

Убрал этот тред совсем, перенёс публикацию в `main`, а `paho` в его родной тред через `loop_start`.