### PR TITLE
Use mqtt client wrapper from wb-common

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-metrics (0.3.0) stable; urgency=medium
+
+  * use mqtt client wrapper from wb-common
+  * enable logging to journald
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 18:39:00 +0400
+
 wb-mqtt-metrics (0.2.3) stable; urgency=medium
 
   * do not use additional thread to publish values

--- a/debian/control
+++ b/debian/control
@@ -5,12 +5,12 @@ Maintainer: Semen Sokolov <s.sokolov@wirenboard.ru>
 Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, pkg-config
 Standards-Version: 4.5.0
 Homepage: https://github.com/wirenboard/wb-mqtt-metrics/
-X-Python3-Version: >= 3.2
+X-Python3-Version: >= 3.5
 
 Package: python3-wb-mqtt-metrics
 Section: python
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-yaml, python3-paho-mqtt, python3-paho-socket
+Depends: ${python3:Depends}, ${misc:Depends}, python3-systemd, python3-wb-common (>= 2.1.0), python3-yaml
 Description: python3 library for sending metrics to mqtt-channels
 
 Package: wb-mqtt-metrics

--- a/wb/mqtt_metrics/device_messenger.py
+++ b/wb/mqtt_metrics/device_messenger.py
@@ -1,8 +1,8 @@
-from paho.mqtt import client as mqtt_client
+from wb_common.mqtt_client import MQTTClient
 
 
 class DeviceMessenger:
-    def __init__(self, client: mqtt_client, device_name):
+    def __init__(self, client: MQTTClient, device_name: str):
         self.client = client
         self.device_name = device_name
 

--- a/wb/mqtt_metrics/metrics_sender.py
+++ b/wb/mqtt_metrics/metrics_sender.py
@@ -30,7 +30,7 @@ def connect_mqtt(broker_url) -> MQTTClient:
     client = MQTTClient("wb-mqtt-metrics", broker_url)
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
-    client.connect()
+    client.start()
 
     return client
 
@@ -66,7 +66,7 @@ def main(argv=None):
                 metric.send(messenger)
             time.sleep(period)
     finally:
-        client.disconnect()
+        client.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on https://github.com/wirenboard/wb-common/pull/8

Test instructions:
```sh
$ systemctl status wb-mqtt-metrics
...
Mar 01 11:30:43 wirenboard-A7PWH4NX systemd[1]: Started metrics sender..
Mar 01 11:30:48 wirenboard-A7PWH4NX /usr/bin/wb-metrics[2297]: Connected to MQTT Broker unix:///var/run/mosquitto/mosquitto.sock!
$ sed -i 's#unix:///var/run/mosquitto/mosquitto.sock#tcp://127.0.0.1:1883#' /etc/wb-mqtt-metrics.conf
$ systemctl restart wb-mqtt-metrics
$ systemctl status wb-mqtt-metrics
...
Mar 01 11:41:20 wirenboard-A7PWH4NX systemd[1]: Started metrics sender..
Mar 01 11:41:21 wirenboard-A7PWH4NX /usr/bin/wb-metrics[13440]: Connected to MQTT Broker tcp://127.0.0.1:1883!
$ sed -i 's#tcp://127.0.0.1:1883#ws://127.0.0.1:18883#' /etc/wb-mqtt-metrics.conf
$ systemctl restart wb-mqtt-metrics
$ systemctl status wb-mqtt-metrics
...
Mar 01 11:43:00 wirenboard-A7PWH4NX systemd[1]: Started metrics sender..
Mar 01 11:43:01 wirenboard-A7PWH4NX /usr/bin/wb-metrics[14844]: Connected to MQTT Broker ws://127.0.0.1:18883!
$ mqtt-get-dump '/devices/metrics/controls/ram_available/#'
/devices/metrics/controls/ram_available/meta/type	value
/devices/metrics/controls/ram_available/meta/units	MiB
/devices/metrics/controls/ram_available/meta/min	0
/devices/metrics/controls/ram_available	791
```