### PR TITLE
Add name of a driver publishing the device

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-metrics (0.3.3) stable; urgency=medium
+
+  * Add name of a driver publishing the device
+  * Add device title translation
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 19 Mar 2024 10:39:00 +0400
+
 wb-mqtt-metrics (0.3.2) stable; urgency=medium
 
   * Fix pylint errors. No functional changes

--- a/wb/mqtt_metrics/device_messenger.py
+++ b/wb/mqtt_metrics/device_messenger.py
@@ -1,3 +1,5 @@
+import json
+
 from wb_common.mqtt_client import MQTTClient
 
 
@@ -6,7 +8,10 @@ class DeviceMessenger:
         self.client = client
         self.device_name = device_name
 
-        client.publish(f"/devices/{self.device_name}/meta/name", self.device_name, retain=True, qos=1)
+        meta = {"driver": "wb-mqtt-metrics", "title": {"en": "Metrics", "ru": "Метрики"}}
+        client.publish(f"/devices/{self.device_name}/meta", json.dumps(meta), retain=True, qos=1)
+        client.publish(f"/devices/{self.device_name}/meta/driver", meta["driver"], retain=True, qos=1)
+        client.publish(f"/devices/{self.device_name}/meta/name", meta["title"]["en"], retain=True, qos=1)
         client.publish(f"/devices/{self.device_name}/meta/error", None, retain=True, qos=1)
 
     def publish(self, topic, value):


### PR DESCRIPTION
According to https://github.com/wirenboard/conventions?tab=readme-ov-file#devices-meta-topic

<img width="1011" alt="Näyttökuva 2024-3-19 kello 10 54 23" src="https://github.com/wirenboard/wb-mqtt-metrics/assets/688044/9b900211-e40d-4b53-b7f1-b024bb70526b">
<img width="458" alt="Näyttökuva 2024-3-19 kello 10 50 41" src="https://github.com/wirenboard/wb-mqtt-metrics/assets/688044/ba4624b9-f8da-4459-947e-321886b22d57">